### PR TITLE
Added typset formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules
+node_modules/
 .DS_STORE

--- a/renderer.js
+++ b/renderer.js
@@ -4,6 +4,11 @@ function onTextInput() {
     let math_text = document.getElementById("math-input").value
     let math_rendered = ipcRenderer.send("textChanged",math_text);  
 }
+
+ipcRenderer.on("updateFormat", function(event) {
+    onTextInput()
+})
+
 function disableTyping(key) {
     if( key.keyCode >= 37 && key.keyCode <= 40 ) {
         return; // arrow keys


### PR DESCRIPTION
Bear equation editor can now switch between input formats on the fly using the 'Edit' menu or keyboard shortcuts:

- AsciiMath: Cmd+Shift+A
- LaTeX: Cmd+Shift+L
- MathML: Cmd+Shift+M

The default is still AsciiMath